### PR TITLE
Fixed archetype in schema

### DIFF
--- a/docs/InventoryInjector.schema.json
+++ b/docs/InventoryInjector.schema.json
@@ -852,13 +852,13 @@
     "match-archetype": {
       "description": "Spell Archetype",
       "anyOf": [
-        { "$ref": "#/$defs/weaponType" },
+        { "$ref": "#/$defs/archetype" },
         {
           "type": "object",
           "properties": {
             "anyOf": {
               "type": "array",
-              "items": { "$ref": "#/$defs/weaponType" }
+              "items": { "$ref": "#/$defs/archetype" }
             }
           }
         }

--- a/docs/InventoryInjector.schema.json
+++ b/docs/InventoryInjector.schema.json
@@ -199,7 +199,22 @@
               "spellCostDisplay": { "$ref": "#/$defs/assign-data" },
               "timeRemainingDisplay": { "$ref": "#/$defs/assign-data" },
               "cardName": { "$ref": "#/$defs/assign-data" },
-              "effectName": { "$ref": "#/$defs/assign-data" }
+              "effectName": { "$ref": "#/$defs/assign-data" },
+              "itemType": { "$ref": "#/$defs/assign-data" },
+              "itemClass": { "$ref": "#/$defs/assign-data" },
+              "itemSort": { "$ref": "#/$defs/assign-data" },
+              "magicSchool": { "$ref": "#/$defs/assign-data" },
+              "armorClass": { "$ref": "#/$defs/assign-data" },
+              "weightClass": { "$ref": "#/$defs/assign-data" },
+              "magicClassDisplay": { "$ref": "#/$defs/assign-data" },
+              "equipType": { "$ref": "#/$defs/assign-data" },
+              "equipTypeDisplay": { "$ref": "#/$defs/assign-data" },
+              "SHHunger": { "$ref": "#/$defs/assign-data" },
+              "SHThirst": { "$ref": "#/$defs/assign-data" },
+              "SHFW": { "$ref": "#/$defs/assign-data" },
+              "infoHunger": { "$ref": "#/$defs/assign-data" },
+              "restoreCold": { "$ref": "#/$defs/assign-data" },
+              "fWarmth": { "$ref": "#/$defs/assign-data" }
             },
             "minProperties": 1
           }


### PR DESCRIPTION
`match-archetype` was improperly referencing `weaponType` instead of `archetype`, causing editors to display errors.